### PR TITLE
Modified Podfile to get Kiwi from CocoaPods

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 platform :ios, "6.1"
 
 target :TrafficLightsTests, :exclusive => true do
-    pod 'Kiwi', :path => '/Users/Tim/codeLibraries/Kiwi'
+    pod 'Kiwi'
 end


### PR DESCRIPTION
Removed reference to local filepath in Podfile.
Allows Kiwi to be installed from Cocoapods

``` objc
 pod install
```
